### PR TITLE
Update dependencies and add kubectl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,25 @@
-FROM buildkite/agent:2.6.3
-MAINTAINER Democracy Works, Inc. <dev@democracy.works>
+FROM buildkite/agent:2.6.5
+LABEL maintainer="Democracy Works, Inc. <dev@democracy.works>"
 
-ENV FLEETCTL_VERSION 0.11.8
+ARG FLEETCTL_VERSION=0.11.8
+ARG KUBECTL_VERSION=1.7.5
 
-# install openssl, jq and aws
-RUN pip install awscli
-RUN apk add --update --no-cache openssl jq
-
-# install fleetctl
-ADD https://github.com/coreos/fleet/releases/download/v${FLEETCTL_VERSION}/fleet-v${FLEETCTL_VERSION}-linux-amd64.tar.gz /tmp/fleet.tar.gz
-RUN tar -C /tmp -xzf /tmp/fleet.tar.gz && mv /tmp/fleet-v${FLEETCTL_VERSION}-linux-amd64/fleetctl /bin/ && \
-    rm -rf /tmp/fleet-v${FLEETCTL_VERSION}-linux-amd64 && rm /tmp/fleet.tar.gz
+RUN apk add --no-cache \
+## Install OpenSSL
+    openssl \
+  && pip install \
+## Install AWS CLI
+     awscli \
+## Install kubectl
+  && curl -sSo /usr/local/bin/kubectl \
+     https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl \
+  && chmod +x /usr/local/bin/kubectl \
+## Install fleetctl
+  && curl -sSLo /tmp/fleet.tar.gz \
+     https://github.com/coreos/fleet/releases/download/v${FLEETCTL_VERSION}/fleet-v${FLEETCTL_VERSION}-linux-amd64.tar.gz \
+  && tar -C /tmp -xzf /tmp/fleet.tar.gz \
+  && mv /tmp/fleet-v${FLEETCTL_VERSION}-linux-amd64/fleetctl /usr/local/bin/ \
+  && chmod +x /usr/local/bin/fleetctl \
+  && rm -rf /tmp/fleet*
 
 COPY hooks /buildkite/hooks

--- a/buildkite-a@.service
+++ b/buildkite-a@.service
@@ -12,7 +12,7 @@ TimeoutStopSec=10m
 Restart=on-failure
 
 Environment=DOCKER_REPO=quay.io/democracyworks/buildkite-agent-coreos
-Environment=VERSION=2.6.3
+Environment=VERSION=2.6.5
 Environment=CONTAINER=buildkite-agent-a
 Environment=HOME=/root
 

--- a/buildkite-a@.service
+++ b/buildkite-a@.service
@@ -27,9 +27,7 @@ ExecStart=/bin/bash -c 'docker run --name ${CONTAINER} \
   --env FLEETCTL_ENDPOINT=http://${COREOS_PRIVATE_IPV4}:4001 \
   --env DOCKERCFG=\"$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/buildkite/dockercfg?raw)\" \
   --env SSH_PRIVATE_RSA_KEY=\"$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/github/deploy-private-key?raw)\" \
-  --env DOCKER_API_VERSION=\"$(docker version | grep "Server API version:" | awk \'{print $4}\')\" \
   --volume /var/run/docker.sock:/var/run/docker.sock \
-  --volume /opt/bin/docker.static:/bin/docker \
   ${DOCKER_REPO}:${VERSION}'
 
 # USR2 will tell the agent to wrap up any currently-running builds and then shutdown

--- a/buildkite-b@.service
+++ b/buildkite-b@.service
@@ -12,7 +12,7 @@ TimeoutStopSec=10m
 Restart=on-failure
 
 Environment=DOCKER_REPO=quay.io/democracyworks/buildkite-agent-coreos
-Environment=VERSION=2.6.3
+Environment=VERSION=2.6.5
 Environment=CONTAINER=buildkite-agent-b
 Environment=HOME=/root
 

--- a/buildkite-b@.service
+++ b/buildkite-b@.service
@@ -27,9 +27,7 @@ ExecStart=/bin/bash -c 'docker run --name ${CONTAINER} \
   --env FLEETCTL_ENDPOINT=http://${COREOS_PRIVATE_IPV4}:4001 \
   --env DOCKERCFG=\"$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/buildkite/dockercfg?raw)\" \
   --env SSH_PRIVATE_RSA_KEY=\"$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/github/deploy-private-key?raw)\" \
-  --env DOCKER_API_VERSION=\"$(docker version | grep "Server API version:" | awk \'{print $4}\')\" \
   --volume /var/run/docker.sock:/var/run/docker.sock \
-  --volume /opt/bin/docker.static:/bin/docker \
   ${DOCKER_REPO}:${VERSION}'
 
 # USR2 will tell the agent to wrap up any currently-running builds and then shutdown

--- a/buildkite@.service
+++ b/buildkite@.service
@@ -27,9 +27,7 @@ ExecStart=/bin/bash -c 'docker run --name ${CONTAINER} \
   --env FLEETCTL_ENDPOINT=http://${COREOS_PRIVATE_IPV4}:4001 \
   --env DOCKERCFG=\"$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/buildkite/dockercfg?raw)\" \
   --env SSH_PRIVATE_RSA_KEY=\"$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/github/deploy-private-key?raw)\" \
-  --env DOCKER_API_VERSION=\"$(docker version | grep "Server API version:" | awk \'{print $4}\')\" \
   --volume /var/run/docker.sock:/var/run/docker.sock \
-  --volume /opt/bin/docker.static:/usr/bin/docker \
   ${DOCKER_REPO}:${VERSION}'
 
 # USR2 will tell the agent to wrap up any currently-running builds and then shutdown

--- a/buildkite@.service
+++ b/buildkite@.service
@@ -12,7 +12,7 @@ TimeoutStopSec=10m
 Restart=on-failure
 
 Environment=DOCKER_REPO=quay.io/democracyworks/buildkite-agent-coreos
-Environment=VERSION=2.6.3
+Environment=VERSION=2.6.5
 Environment=CONTAINER=buildkite-agent
 Environment=HOME=/root
 


### PR DESCRIPTION
- Buildkite agent version is now 2.6.5
- `fleetctl` version is now 1.0.0
- `kubectl` is added at version 1.7.5

`jq` is removed from this image as it is part of the parent image, so functionality should be maintained.

`kubectl` is being added to support deploying to Kubernetes. Regardless of the direction we go in architecting our deployments to Kubernetes, we will almost certainly need `kubectl` on Buildkite, just as we have `fleetctl`.

**Question:**

- Do we need to mount the Docker client binary from the host into the container? The image includes Docker. Were there compatibility issues in the past?