### PR TITLE
Upgrade agent to v3.0-beta.38

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildkite/agent:2.6.5
+FROM buildkite/agent:3.0-beta.38
 LABEL maintainer="Democracy Works, Inc. <dev@democracy.works>"
 
 ARG FLEETCTL_VERSION=0.11.8

--- a/buildkite-a@.service
+++ b/buildkite-a@.service
@@ -12,7 +12,7 @@ TimeoutStopSec=10m
 Restart=on-failure
 
 Environment=DOCKER_REPO=quay.io/democracyworks/buildkite-agent-coreos
-Environment=VERSION=2.6.5
+Environment=VERSION=3.0-beta.38
 Environment=CONTAINER=buildkite-agent-a
 Environment=HOME=/root
 

--- a/buildkite-b@.service
+++ b/buildkite-b@.service
@@ -12,7 +12,7 @@ TimeoutStopSec=10m
 Restart=on-failure
 
 Environment=DOCKER_REPO=quay.io/democracyworks/buildkite-agent-coreos
-Environment=VERSION=2.6.5
+Environment=VERSION=3.0-beta.38
 Environment=CONTAINER=buildkite-agent-b
 Environment=HOME=/root
 

--- a/buildkite@.service
+++ b/buildkite@.service
@@ -12,7 +12,7 @@ TimeoutStopSec=10m
 Restart=on-failure
 
 Environment=DOCKER_REPO=quay.io/democracyworks/buildkite-agent-coreos
-Environment=VERSION=2.6.5
+Environment=VERSION=3.0-beta.38
 Environment=CONTAINER=buildkite-agent
 Environment=HOME=/root
 


### PR DESCRIPTION
The 3.0 agent has been out for a very long time, and there are now sections of the Buildkite documentation recommending an upgrade to the 3.0 line, despite the "beta" marker. It seems like it is in a relatively stable spot.

There are very few (no?) breaking changes that I am aware of, however the main difference is that we can put variables in `pipeline.yml` that are interpreted at runtime, which we are starting to make use of in newer builds.